### PR TITLE
docs: factual README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,100 @@
-Install
+# SQD Network indexer (squid-subsquid-network)
+
+A Squid SDK indexer for the SQD Network's onchain contracts. It reads SQD Network smart contract events on Arbitrum and exposes the indexed data over a GraphQL API.
+
+## What it is
+
+SQD ([sqd.dev](https://sqd.dev)) is an open data platform for Web3. The [SQD Network](https://sqd.dev/network) is a decentralized data lake whose token, staking, worker, and gateway logic lives in onchain contracts. This repository indexes those contracts and serves the resulting state through GraphQL.
+
+It is built with the [Squid SDK](https://docs.sqd.dev/en/sdk), reads block data through the [SQD Portal](https://portal.sqd.dev/datasets/arbitrum-one), stores data in PostgreSQL via TypeORM, and serves it with the Squid GraphQL server.
+
+The contract ABIs are in `abi/`. The contract sources and addresses live in a separate repository: [subsquid/subsquid-network-contracts](https://github.com/subsquid/subsquid-network-contracts).
+
+## Layout
+
+This is a pnpm + Turborepo monorepo (`packages/`). It contains three indexers plus shared code:
+
+| Package | Indexes |
+|---|---|
+| `@sqd/token` | The SQD token, transfers, accounts, vestings, and temporary holdings |
+| `@sqd/gateways` | Gateways, gateway stakes, and portal pools |
+| `@sqd/workers` | Workers, delegations, rewards, epochs, and uptime/metrics snapshots |
+| `@sqd/shared` | Shared ABIs, network config, and helpers used by the indexers |
+
+Each indexer has its own GraphQL schema (`packages/*/schema.graphql`), database migrations (`packages/*/db/`), and processor entry point (`packages/*/src/main.ts`).
+
+The indexers run against two networks: `mainnet` (Arbitrum One) and `tethys` testnet (Arbitrum Sepolia). Deployment manifests for both are in `manifests/`.
+
+## Requirements
+
+- Node.js
+- pnpm (the workspace pins `pnpm@10.30.2`)
+- Docker (for the local PostgreSQL instance)
+
+## Setup
+
+Install dependencies:
+
 ```bash
-yarn
+pnpm install
 ```
 
-Build
+Copy the example environment file and adjust as needed:
+
 ```bash
-sqd build
+cp .env.example .env
 ```
 
-Run
+`.env.example` lists the variables the indexers read, including the RPC endpoint, the Portal endpoint, and the database connection.
+
+## Build
+
+Generate TypeORM models from the GraphQL schemas, then build all packages:
+
 ```bash
-sqd up
-sqd run .
+pnpm codegen
+pnpm build
 ```
+
+## Run
+
+Start the local PostgreSQL databases (the compose file creates one database per indexer):
+
+```bash
+docker compose up -d
+```
+
+Apply database migrations:
+
+```bash
+pnpm db:migrate
+```
+
+Run a single indexer's processor and GraphQL API from its package directory, for example the token indexer:
+
+```bash
+pnpm --dir packages/token proc   # run the processor
+pnpm --dir packages/token api    # serve the GraphQL API
+```
+
+Use `packages/gateways` or `packages/workers` in place of `packages/token` to run the other indexers.
+
+## Scripts
+
+Defined at the workspace root (`package.json`):
+
+- `pnpm build`: build all packages
+- `pnpm codegen`: generate TypeORM models from the GraphQL schemas
+- `pnpm db:migrate`: apply database migrations
+- `pnpm clean`: remove build output
+- `pnpm lint`: run Biome with autofix
+
+## License
+
+MIT. See [LICENSE](./LICENSE).
+
+## Documentation
+
+- SQD documentation: https://docs.sqd.dev
+- Squid SDK: https://docs.sqd.dev/en/sdk
+- SQD Network: https://docs.sqd.dev/en/network


### PR DESCRIPTION
## Summary

Replaces the 15-line stub README (which used outdated `yarn` / `sqd build` / `sqd up` commands that no longer match the project) with a factual, plain-language README describing what the repository actually is.

## What this repo is (verified from source)

A Squid SDK indexer for the SQD Network's onchain contracts on Arbitrum, served over GraphQL. It is a pnpm + Turborepo monorepo with three indexers plus shared code.

## What I confirmed and from which files

- **Name / monorepo structure**: `package.json` (`name: squid-subsquid-network`, `private`, Turbo scripts), `pnpm-workspace.yaml` (`packages/*`), `turbo.json`.
- **Three indexer packages**: `packages/token`, `packages/gateways`, `packages/workers`, plus `packages/shared` (each `packages/*/package.json` confirms names `@sqd/token`, `@sqd/gateways`, `@sqd/workers`, `@sqd/shared` and Squid SDK deps: `@subsquid/batch-processor`, `@subsquid/evm-stream`, `@subsquid/typeorm-store`, `@subsquid/graphql-server`, `@subsquid/typeorm-migration`).
- **What each indexer captures**: GraphQL `type` entities in `packages/token/schema.graphql` (Account, Transfer, Vesting, TemporaryHolding), `packages/gateways/schema.graphql` (Gateway, GatewayStake, PortalPool), `packages/workers/schema.graphql` (Worker, Delegation, WorkerReward, Epoch, WorkerSnapshot/Metrics).
- **Arbitrum + Portal + networks**: `.env.example` and `manifests/*/{mainnet,testnet}.squid.yaml` (NETWORK `mainnet`/`tethys`, RPC `arb1.arbitrum.io` / `arb-sepolia`, PORTAL_ENDPOINT `portal.sqd.dev/datasets/arbitrum-one` / `arbitrum-sepolia`). Confirmed in `packages/workers/src/config/processor.ts` (DataSourceBuilder + setPortal).
- **Contracts are external**: `.gitmodules` and `abi/` (DistributedRewardsDistribution, GatewayRegistry, NetworkController, Staking, WorkerRegistration, SQD, etc.) point to `subsquid/subsquid-network-contracts`.
- **Local DB / scripts**: `docker-compose.yml` (postgres:16, one DB per indexer), root scripts `build`/`codegen`/`db:migrate`/`clean`/`lint` (Biome), pnpm pinned to `pnpm@10.30.2`.
- **License**: `LICENSE` is MIT (Copyright 2022 Subsquid).

## Links (all verified HTTP 200)

- https://sqd.dev
- https://sqd.dev/network
- https://docs.sqd.dev
- https://docs.sqd.dev/en/sdk
- https://docs.sqd.dev/en/network
- https://portal.sqd.dev/datasets/arbitrum-one
- https://github.com/subsquid/subsquid-network-contracts

## Style

No marketing language, no em dashes, "onchain" written as one word, no unverified performance claims. README only; no code or config touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)